### PR TITLE
Resolve print media URLs for absolute CDN and legacy API paths.

### DIFF
--- a/src/app/utils/constructor-utils.ts
+++ b/src/app/utils/constructor-utils.ts
@@ -4,7 +4,7 @@ import { IPrintFile } from "./types";
 import { IInitialPrintParams } from "./types";
 import { IStageParams } from "./types";
 import { v4 as uuidv4 } from 'uuid';
-import { apiBaseUrl } from "./constants";
+import { resolveMediaUrl } from "./product-photos";
 import * as THREE from 'three';
 import { TParams } from "./types";
 
@@ -165,7 +165,7 @@ export const setCoords = (currentImage: IInitialPrintParams, activeView: string,
 
   let params = {
     
-      url: currentImage.url ? `${apiBaseUrl}${currentImage.url}` : undefined,
+      url: currentImage.url ? resolveMediaUrl(currentImage.url) : undefined,
       decalRotation: [0,0,0],
       //decalPosition: [0,0.1,0],
       decalPosition: [0,0.1,0.1],

--- a/src/app/utils/product-photos.ts
+++ b/src/app/utils/product-photos.ts
@@ -18,8 +18,11 @@ export type TProductPhotoInput = Partial<
 /** Media URLs are either full CDN addresses or legacy API paths like /images/... */
 export const absoluteMediaUrl = (url?: string | null): string => {
   if (!url) return "";
-  return url.startsWith("http") ? url : `${apiBaseUrl}${url}`;
+  return /^https?:\/\//i.test(url) ? url : `${apiBaseUrl}${url}`;
 };
+
+/** Alias for print / upload URLs (CDN absolute or legacy `/uploads/...`). */
+export const resolveMediaUrl = absoluteMediaUrl;
 
 /**
  * Resolves the photo at `index`: a migrated product serves it straight from

--- a/src/components/pages-components/cart-page/print-preview/print-preview.tsx
+++ b/src/components/pages-components/cart-page/print-preview/print-preview.tsx
@@ -5,7 +5,7 @@ import { ICartOrderElement } from "@/app/utils/types";
 import { BASIC_PRINT_COST, getPreviewArrFunc, ruPrintPlace } from "@/app/utils/cart-utils";
 import { actions as cartActions } from "@/redux/cart-slice/cart.slice";
 import { useAppDispatch } from "@/redux/redux-hooks";
-import { apiBaseUrl } from "@/app/utils/constants";
+import { resolveMediaUrl } from "@/app/utils/product-photos";
 
 
 
@@ -35,7 +35,7 @@ const PrintPreview: React.FC<{ elem: ICartOrderElement }> = ({ elem }) => {
                   >
                     <img
                       className={styles.cart_previewImg}
-                      src={`${apiBaseUrl}${item.file?.url}`}
+                      src={resolveMediaUrl(item.file?.url)}
                       alt={item.file?.name || "Файл принта"}
                     />
                      <div className={styles.prints_info}>

--- a/src/components/pages-components/constructor-page/3dmockup/3dmokup.tsx
+++ b/src/components/pages-components/constructor-page/3dmockup/3dmokup.tsx
@@ -16,7 +16,6 @@ import {
 } from "@react-three/drei";
 import { easing } from "maath";
 import { useAppDispatch, useAppSelector } from "@/redux/redux-hooks";
-import { apiBaseUrl } from "@/app/utils/constants";
 import { ICartOrderElement } from "@/app/utils/types";
 import { useSearchParams } from "next/navigation";
 import { useUploadPrintImageMutation } from "@/api/api";

--- a/src/components/pages-components/constructor-page/3dmockup/decal.tsx
+++ b/src/components/pages-components/constructor-page/3dmockup/decal.tsx
@@ -8,7 +8,7 @@ import {
   Decal,
 } from "@react-three/drei";
 import { useAppDispatch, useAppSelector } from "@/redux/redux-hooks";
-import { apiBaseUrl } from "@/app/utils/constants";
+import { resolveMediaUrl } from "@/app/utils/product-photos";
 import { actions as cartActions } from "@/redux/cart-slice/cart.slice";
 import { useSearchParams } from "next/navigation";
 import { useUploadPrintImageMutation } from '@/api/api';
@@ -55,7 +55,7 @@ const DecalComp = () => {
     const [ pivotAxis, setPivotAxis ] = useState<number>(); 
    
    
-    const url = currPrint?.file?.url ? `${apiBaseUrl}${currPrint.file.url}` : '/whiteTexture.png';
+    const url = currPrint?.file?.url ? resolveMediaUrl(currPrint.file.url) : '/whiteTexture.png';
     const texture = useTexture(url, () => { if (currPrint && !currPrint.preview) {return document.querySelector('canvas')?.toBlob((blob) => {getScene(activeView, blob);});}});
     //const texture = useTexture(url);
    

--- a/src/components/pages-components/constructor-page/3dmockup/preview.tsx
+++ b/src/components/pages-components/constructor-page/3dmockup/preview.tsx
@@ -14,7 +14,7 @@ import {
 } from "@react-three/drei";
 import { easing } from "maath";
 import { useAppSelector } from "@/redux/redux-hooks";
-import { apiBaseUrl } from "@/app/utils/constants";
+import { resolveMediaUrl } from "@/app/utils/product-photos";
 import { ICartOrderElement } from "@/app/utils/types";
 import { useSearchParams } from "next/navigation";
 import classNames from "classnames/bind";
@@ -165,10 +165,10 @@ const Prints = () => {
   //@ts-ignore
   const { front, back, lsleeve, rsleeve } = orderElement?.prints;
 
-  const frontPrint = useTexture(front?.file?.url ? `${apiBaseUrl}${front.file.url}` : '/whiteTexture.png');
-  const backPrint = useTexture(back?.file?.url ? `${apiBaseUrl}${back.file.url}` : '/whiteTexture.png');
-  const lsleevePrint = useTexture(lsleeve?.file?.url ? `${apiBaseUrl}${lsleeve.file.url}` : '/whiteTexture.png');
-  const rsleevePrint = useTexture(rsleeve?.file?.url ? `${apiBaseUrl}${rsleeve.file.url}` : '/whiteTexture.png');
+  const frontPrint = useTexture(front?.file?.url ? resolveMediaUrl(front.file.url) : '/whiteTexture.png');
+  const backPrint = useTexture(back?.file?.url ? resolveMediaUrl(back.file.url) : '/whiteTexture.png');
+  const lsleevePrint = useTexture(lsleeve?.file?.url ? resolveMediaUrl(lsleeve.file.url) : '/whiteTexture.png');
+  const rsleevePrint = useTexture(rsleeve?.file?.url ? resolveMediaUrl(rsleeve.file.url) : '/whiteTexture.png');
   return (
       
       

--- a/src/components/pages-components/shop-page/print-add-block/print-add-block.tsx
+++ b/src/components/pages-components/shop-page/print-add-block/print-add-block.tsx
@@ -7,7 +7,7 @@ import { photoProcessing } from '@/app/utils/constructor-utils';
 import { useAppDispatch, useAppSelector } from '@/redux/redux-hooks';
 import { actions as utilActions } from '@/redux/utils-slice/utils.slice';
 import { useUploadPrintImageMutation } from '@/api/api';
-import { apiBaseUrl } from '@/app/utils/constants';
+import { resolveMediaUrl } from '@/app/utils/product-photos';
 
 
 const TABS = [
@@ -87,7 +87,7 @@ export const PrintAddBlock: React.FC<{ item: IProduct }> = ({ item }) => {
                                 {!isPrintImageLoading && currentPrint && (
                                     <div className={styles.printInfo_wrapper}>
                                         <div className={styles.printInfo_image}>
-                                            <img src={`${apiBaseUrl}${currentPrint.file?.url}`} alt={currentPrint.file?.name} />
+                                            <img src={resolveMediaUrl(currentPrint.file?.url)} alt={currentPrint.file?.name} />
                                         </div>
                                         <span className={styles.printInfo_note} style={{ color: 'black' }}>{currentPrint.file?.name}</span>
                                         <div className={styles.printDeleteButton_wrapper}>

--- a/src/konva-stage/print.tsx
+++ b/src/konva-stage/print.tsx
@@ -7,7 +7,7 @@ import {
 import { useAppDispatch, useAppSelector } from '@/redux/redux-hooks';
 import useImage from 'use-image';
 import { ICartOrderElement } from '@/app/utils/types';
-import { apiBaseUrl } from '@/app/utils/constants';
+import { resolveMediaUrl } from '@/app/utils/product-photos';
 //import styles from './constructor-page.module.css';
 // import circle50px from '../../components/images/circle50px.png';
 
@@ -44,7 +44,7 @@ const Print: React.FC<TPrintProps> = ({
   const dispatch = useAppDispatch();
   const { activeView } = useAppSelector((store) => store.printConstructor);
   //eslint-ignore-next-line
-  const [imageTwo] = file ? useImage(`${apiBaseUrl}${file}`, 'anonymous') : useImage('', 'anonymous'); // eslint-disable-line react-hooks/rules-of-hooks
+  const [imageTwo] = file ? useImage(resolveMediaUrl(file), 'anonymous') : useImage('', 'anonymous'); // eslint-disable-line react-hooks/rules-of-hooks
 
   useEffect(() => {
       imageTwo && scene(activeView);

--- a/src/redux/cart-slice/cart.slice.ts
+++ b/src/redux/cart-slice/cart.slice.ts
@@ -5,7 +5,7 @@ import { IUploadPrintResponse } from "@/app/utils/types";
 import { setCoords } from "@/app/utils/constructor-utils";
 import { getPrintFormatAndPriceFunc } from "@/app/utils/constructor-utils";
 import { IStageParams, ICdekCitySearchResponse } from "@/app/utils/types";
-import { apiBaseUrl } from "@/app/utils/constants";
+import { resolveMediaUrl } from "@/app/utils/product-photos";
 
 interface IInitialState {
     order?: Array<ICartOrderElement>,
@@ -145,11 +145,10 @@ const cartSlice = createSlice({
         },
         setPreview: (state, action: PayloadAction<{preview: IUploadPrintResponse, activeView: string, itemCartId: string }>) => {
             const { preview, activeView, itemCartId} = action.payload;
-            //console.log(`${apiBaseUrl}${preview.data.url}`);
             state.order?.forEach((elem) => {
                 if (elem.itemCartId === itemCartId) {
                     // @ts-ignore
-                    elem.prints![activeView].preview = `${apiBaseUrl}${preview.data.url}`;
+                    elem.prints![activeView].preview = resolveMediaUrl(preview.data.url);
                 }
             })
             sessionStorage.setItem('order', JSON.stringify(state.order));


### PR DESCRIPTION
Avoid prefixing apiBaseUrl onto full https://cdn.pnhd.ru/prints/... responses after S3 upload.